### PR TITLE
"thresholds" and "thresholdConfig" props

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Show list of progress items by mapping your data.",
   "author": "CorpGlory Inc.",
-  "private": true,
+  "private": false,
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build"

--- a/src/components/ProgressItem.vue
+++ b/src/components/ProgressItem.vue
@@ -5,35 +5,56 @@
       <div
         v-bind:style="{
           width: progress + '%',
+          backgroundColor: getItemColor(item),
+          opacity: config.opacity
         }"
         class="progress-bar-line"
       />
-      <span
-        style="margin-top: -15px;"
-        class="list-item-value progress-bar-value"
-      >
-        {{ progress }}
+      <span class="list-item-value progress-bar-value">
+        {{ progress }}%
       </span>
     </div>
   </div>
 </template>
 
 <script lang="ts">
-import { ProgressItemType } from './ProgressList.vue';
-import { Component, Vue, Prop } from 'vue-property-decorator';
+import { Item, Config, Thresholds, ThresholdConfig } from './types';
 
+import { Component, Vue, Prop, Watch } from 'vue-property-decorator';
 
 @Component
 export default class ProgressItem extends Vue {
 
   @Prop({ required: true })
-  item!: ProgressItemType;
+  item!: Item;
 
   @Prop({ required: true })
-  maxValue!: number;
+  config!: Config;
+
+  @Prop({required: false})
+  thresholds!: Thresholds;
+
+  @Prop({required: false})
+  thresholdConfig!: ThresholdConfig;
 
   get progress(): number {
-    return 100 * this.item.value / this.maxValue;
+    return 100 * this.item.value / this.config.maxValue;
+  }
+
+  getItemColor(item: Item): string {
+    if(this.thresholds === undefined) {
+      return item.backgroundColor;
+    } else {
+      if(item.value < this.thresholds.lowerValue){
+        return this.thresholdConfig.lowerColor;
+      } else if(item.value >= this.thresholds.lowerValue && item.value <= this.thresholds.upperValue) {
+        return this.thresholdConfig.middleColor;
+      } else if(item.value > this.thresholds.upperValue) {
+        return this.thresholdConfig.upperColor;
+      } else {
+        throw new Error('Cant get item color');
+      }
+    }
   }
 
 }
@@ -45,7 +66,7 @@ export default class ProgressItem extends Vue {
 }
 .list-item {
   position: relative;
-  height: 25px;
+  height: 30px;
 }
 
 .list-item-content {
@@ -69,11 +90,12 @@ export default class ProgressItem extends Vue {
   background: darkgreen;
 }
 
-.list-item-content .list-item-title {
-  z-index: 1;
+.list-item .progress-bar-value {
+  margin-top: -15px;
 }
 
-.options-tab .section {
-  margin-right: 1rem
+.list-item .list-item-title {
+  text-align: left;
+  z-index: 1;
 }
 </style>

--- a/src/components/ProgressList.vue
+++ b/src/components/ProgressList.vue
@@ -4,7 +4,9 @@
       <div class="center" v-for="(item) in items" :key="item.title">
         <progress-item
           :item="item"
-          :maxValue=config.maxValue
+          :config=config
+          :thresholds=thresholds
+          :thresholdConfig=thresholdConfig
         ></progress-item>
       </div>
     </div>
@@ -13,24 +15,31 @@
 
 <script lang="ts">
 import ProgressItem from './ProgressItem.vue';
-import { Component, Vue, Prop } from 'vue-property-decorator';
 
-// TODO: move types to a separate file
-export type ProgressItemType = {
-  title: string,
-  value: number
+import { Item, Thresholds, ThresholdConfig, Config } from './types';
+
+import { Component, Vue, Prop, Watch } from 'vue-property-decorator';
+
+const DEFAULT_THRESHOLD_CONFIG = {
+  lowerColor: 'green',
+  middleColor: 'orange',
+  upperColor: 'red'
 }
 
 @Component({ components: { ProgressItem } })
 export default class ProgressListPanel extends Vue {
 
   @Prop({ required: true })
-  items!: ProgressItemType[];
+  items!: Item[];
 
   @Prop({ required: true })
-  config!: number;
+  config!: Config;
+
+  @Prop({ required: false })
+  thresholds!: Thresholds;
+
+  @Prop({ required: false, default: () => DEFAULT_THRESHOLD_CONFIG })
+  thresholdConfig!: ThresholdConfig;
 
 }
 </script>
-
-

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -1,0 +1,21 @@
+export type Item = {
+  title: string,
+  value: number,
+  backgroundColor: string
+}
+
+export type Config = {
+  maxValue: number,
+  opacity: number
+}
+
+export type Thresholds = {
+  upperValue: number,
+  lowerValue: number
+}
+
+export type ThresholdConfig = {
+  lowerColor: string,
+  middleColor: string,
+  upperColor: string
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
 import ProgressList from './components/ProgressList.vue';
+import * as ProgressListTypes from './components/types';
 
 export default ProgressList;
+export { ProgressListTypes };


### PR DESCRIPTION

### Changes:
- Item has the new  `backgroundColor: string`  field, which sets color for `progress-bar-line`;
- optional `thresholds` `Prop` with `upperValue: number` and `lowerValue: number`;
- optional `thresholdConfig` `Prop` with `lowerColor: string, middleColor: string, upperColor: string`;
- `private` field in `package.json` changed to `false`;
- if there is no `thresholdConfig`, default is used: 
```js
const DEFAULT_THRESHOLD_CONFIG = {
  lowerColor: 'green',
  middleColor: 'orange',
  upperColor: 'red'
}
```

### default thresholdConfig( upperValue:50, lowerValue: 30)

![image](https://user-images.githubusercontent.com/47055832/69624666-345d8f00-1056-11ea-90a2-9633e2ffc52a.png)

### custom thresholdConfig( upperValue:50, lowerValue: 30)

![image](https://user-images.githubusercontent.com/47055832/69624681-3cb5ca00-1056-11ea-89a1-7fab8b942f4e.png)